### PR TITLE
usb/dwc2/hcd: channel halt may not be an error

### DIFF
--- a/drivers/usb/dwc2/hcd.c
+++ b/drivers/usb/dwc2/hcd.c
@@ -2673,7 +2673,8 @@ static void dwc2_free_dma_aligned_buffer(struct urb *urb)
 		else
 			length = urb->actual_length;
 
-		memcpy(stored_xfer_buffer, urb->transfer_buffer, length);
+		if (stored_xfer_buffer)
+			memcpy(stored_xfer_buffer, urb->transfer_buffer, length);
 	}
 	kfree(urb->transfer_buffer);
 	urb->transfer_buffer = stored_xfer_buffer;

--- a/drivers/usb/dwc2/hcd_intr.c
+++ b/drivers/usb/dwc2/hcd_intr.c
@@ -1964,7 +1964,8 @@ static void dwc2_hc_chhltd_intr_dma(struct dwc2_hsotg *hsotg,
 					"hcint 0x%08x, intsts 0x%08x\n",
 					chan->hcint,
 					dwc2_readl(hsotg, GINTSTS));
-				goto error;
+				dwc2_halt_channel(hsotg, chan, qtd,
+					DWC2_HC_XFER_PERIODIC_INCOMPLETE);
 			}
 		}
 	} else {


### PR DESCRIPTION
Hi,

I've been using your kernel (thanks!), and I sometimes get kernel oops when USB tethering.
Here is how to repro:
- create high load on the CPU: I build a kernel with -j6;
- saturate your cdc_ether connection to the phone (I use netcat on both sides to do so, with termux on android);

I tracked down the issue to buffers getting truncated, the driver extracting a target address from the end of the buffer (weird) & memcpy to a non validated address.

I've fixed it by validating the address we write to & stopped treating un-explained channel closure as errors. I guess the channel is closed due to a timeout (maybe?), caused by heavy context switching on the machine.

I've been testing the following patch for ~1 week and it seems to work well.

Thank you,
Boris.